### PR TITLE
Fix problems with NI 43-101 reports in GeoKB blazegraph store

### DIFF
--- a/harvesters/Sync NI43101 Library.ipynb
+++ b/harvesters/Sync NI43101 Library.ipynb
@@ -1,0 +1,338 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook builds a representation in the GeoKB for the collection of NI 43-101 Technical Reports that we use as cited source material for information on mineral explorations around the world. We store and manage these documents in a Zotero group library, which has its own API, but also represent them here as a place to link additional information gleaned from the documents in various ways. We created a specific type of government report to classify these entities. We use the bibliographic metadata source from the Zotero API and cache both the item metadata and attachment metadata in a YAML encoding on the item talk pages for each report entity. A few key things are done and decided on here:\n",
+    "* build and record a metadata URL provided via the w3id.org service that abstracts away from Zotero's specific landing page construct; these serve a similar function to a DOI in some respects and are treated as a reasonably permanent URL for the items\n",
+    "* build and record one or more content URLs made up of the attachment key coupled with the library ID and item key\n",
+    "* record the attachment key separately for convenience when using the Zotero API to access attachments (requires an API key)\n",
+    "* indicate MIME types for content negotiation or other purposes on the links\n",
+    "* record the version number for each item so that we know where we stand in relation to the base source in Zotero"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyzotero import zotero\n",
+    "import os\n",
+    "from wbmaker import WikibaseConnection\n",
+    "import yaml\n",
+    "\n",
+    "from pymongo import MongoClient\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geokb = WikibaseConnection('GEOKB_CLOUD')\n",
+    "\n",
+    "mongo_client = MongoClient(f\"mongodb://{os.environ['MONGODB_HOST']}:{str(os.environ['MONGODB_PORT'])}/\")\n",
+    "isaid_cache = mongo_client['iSAID']\n",
+    "ni43101_cache = isaid_cache['zotero_ni43101']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "z_ni43101 = zotero.Zotero(\n",
+    "    \"4530692\",\n",
+    "    'group', \n",
+    "    os.environ['ZOTERO_API_KEY']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Caching Zotero Metadata\n",
+    "The process of getting every item from a Zotero group library with thousands of items is long and cumbersome with the throttling that the API uses (50 items at a time). There is a convenient \"everything\" wrapper as well as an iterator in the pyzotero package, but it will still take upwards of 30 minutes to pull 15K reports and their attachments. For that reason, I have a process here that will pull and cache everything in a MongoDB instance that we can work against. This only needs to be run once to baseline the collection, and then we can use the version number to go after new/modified records using the \"since\" parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reports = z_ni43101.everything(z_ni43101.items(itemType='report'))\n",
+    "for item in reports:\n",
+    "    ni43101_cache.update_one({'_id': item['key']}, {'$set': item}, upsert=True)\n",
+    "\n",
+    "attachments = z_ni43101.everything(z_ni43101.items(itemType='attachment'))\n",
+    "for item in attachments:\n",
+    "    ni43101_cache.update_one({'_id': item['key']}, {'$set': item}, upsert=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Updating cache from last version recorded\n",
+    "Here, we pull the max version number from the cache, get new items, and then drop those to the cache. This could be reworked to pull the version from the \"permanent\" records in the GeoKB instead, leaving out the cache."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "78084\n",
+      "78085\n"
+     ]
+    }
+   ],
+   "source": [
+    "max_version_agg = [\n",
+    "    {\n",
+    "        '$group': {\n",
+    "            '_id': None, \n",
+    "            'maxVersion': {\n",
+    "                '$max': '$version'\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "max_version = list(ni43101_cache.aggregate(max_version_agg))[0]['maxVersion']\n",
+    "print(max_version)\n",
+    "\n",
+    "new_items = z_ni43101.everything(z_ni43101.items(since=max_version))\n",
+    "if new_items:\n",
+    "    for item in new_items:\n",
+    "        ni43101_cache.update_one({'_id': item['key']}, {'$set': item}, upsert=True)\n",
+    "\n",
+    "max_version = list(ni43101_cache.aggregate(max_version_agg))[0]['maxVersion']\n",
+    "print(max_version)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## All Cached Docs\n",
+    "We can iterate on the cache, but it is convenient and small enough to pull the entire document set. Documents (items) returned and cached include both the metadata items documenting each report and the attachments (notes are also \"items\" but not used in this context). We put everything into a list of dictionaries for further work below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cached_zotero_items = ni43101_cache.find()\n",
+    "cached_zotero_docs = [i for i in cached_zotero_items]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GeoKB Entities\n",
+    "Here we pull current NI 43-101 entities from the GeoKB via a SPARQL query to produce a simple mapping from Zotero's item key to GeoKB QID. If our strategy is simply to rebuild relevant parts of entities or check for missing entities, this is sufficient. We would need to pull additional claims information if we wanted to do a more sophisticated update operation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "14482\n"
+     ]
+    }
+   ],
+   "source": [
+    "query_geokb_reports = \"\"\"\n",
+    "PREFIX gp: <https://geokb.wikibase.cloud/prop/direct/>\n",
+    "PREFIX ge: <https://geokb.wikibase.cloud/entity/>\n",
+    "\n",
+    "SELECT ?item ?meta_url\n",
+    "WHERE {\n",
+    "  ?item gp:P1 ge:Q10 .\n",
+    "  OPTIONAL {\n",
+    "    ?item gp:P141 ?meta_url .\n",
+    "  }\n",
+    "}\n",
+    "\"\"\"\n",
+    "\n",
+    "geokb_reports = geokb.sparql_query(query_geokb_reports)\n",
+    "geokb_reports['qid'] = geokb_reports['item'].apply(lambda x: x.split('/')[-1])\n",
+    "geokb_reports['z_key'] = geokb_reports['meta_url'].apply(lambda x: x.split('/')[-1] if x else None)\n",
+    "\n",
+    "qid_lookup = geokb_reports.set_index('z_key')['qid'].to_dict()\n",
+    "\n",
+    "print(len(geokb_reports))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Represent Zotero items in GeoKB\n",
+    "The sequence here to work with the GeoKB can be run on all report items pulled from the cache (or simply pulled from Zotero). It relies on the qid_lookup dictionary to determine if we already have an item in place. It will either pull an existing item (based on the Zotero key value in the metadata URL) or create a new item. The sequence (re)builds the item claims directly associated with the Zotero source (ignoring any other claims that might be in place from other sources)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "reports = [i for i in cached_zotero_docs if i['data']['itemType'] == 'report']\n",
+    "missing_reports = [i for i in reports if i['_id'] not in qid_lookup.keys()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for source_doc in missing_reports:\n",
+    "    source_attachments = [i for i in cached_zotero_docs if i['data']['itemType'] == 'attachment' and i['data']['parentItem'] == source_doc['key']]\n",
+    "    qid = qid_lookup.get(source_doc['data']['key'], None)\n",
+    "\n",
+    "    if qid:\n",
+    "        item = geokb.wbi.item.get(qid)\n",
+    "    else:\n",
+    "        item = geokb.wbi.item.new()\n",
+    "\n",
+    "    item.labels.set('en', source_doc['data']['title'])\n",
+    "    item.descriptions.set('en', 'an NI 43-101 Technical Report pulled from the GeoArchive collection')\n",
+    "\n",
+    "    item.claims.add(\n",
+    "        geokb.datatypes.Item(\n",
+    "            prop_nr=geokb.prop_lookup['instance of'],\n",
+    "            value='Q10'\n",
+    "        ),\n",
+    "        action_if_exists=geokb.action_if_exists.REPLACE_ALL\n",
+    "    )\n",
+    "\n",
+    "    item.claims.add(\n",
+    "        geokb.datatypes.URL(\n",
+    "            prop_nr=geokb.prop_lookup['metadata URL'],\n",
+    "            value=f\"https://w3id.org/usgs/z/4530692/{source_doc['key']}\",\n",
+    "            qualifiers=[\n",
+    "                geokb.datatypes.String(\n",
+    "                    prop_nr=geokb.prop_lookup['MIME type'],\n",
+    "                    value='text/html'\n",
+    "                ),\n",
+    "                geokb.datatypes.String(\n",
+    "                    prop_nr=geokb.prop_lookup['MIME type'],\n",
+    "                    value='application/json'\n",
+    "                )\n",
+    "            ]\n",
+    "        ),\n",
+    "        action_if_exists=geokb.action_if_exists.REPLACE_ALL\n",
+    "    )\n",
+    "\n",
+    "    item.claims.add(\n",
+    "        geokb.datatypes.Quantity(\n",
+    "            prop_nr=geokb.prop_lookup['Zotero Version Number'],\n",
+    "            amount=source_doc['version']\n",
+    "        ),\n",
+    "        action_if_exists=geokb.action_if_exists.REPLACE_ALL\n",
+    "    )\n",
+    "\n",
+    "    attachment_claims = []\n",
+    "    for attachment in source_attachments:\n",
+    "        attachment_qualifiers = geokb.models.Qualifiers()\n",
+    "        attachment_qualifiers.add(\n",
+    "            geokb.datatypes.String(\n",
+    "                prop_nr=geokb.prop_lookup['MIME type'],\n",
+    "                value=attachment['data']['contentType']\n",
+    "            )\n",
+    "        )\n",
+    "        attachment_qualifiers.add(\n",
+    "            geokb.datatypes.String(\n",
+    "                prop_nr=geokb.prop_lookup['checksum'],\n",
+    "                value=attachment['data']['md5']\n",
+    "            )\n",
+    "        )\n",
+    "\n",
+    "        attachment_claims.append(\n",
+    "            geokb.datatypes.URL(\n",
+    "                prop_nr=geokb.prop_lookup['content URL'],\n",
+    "                value=f\"https://www.zotero.org/groups/4530692/usgs_ni_43-101_reports/items/{source_doc['key']}/attachment/{attachment['key']}/reader\",\n",
+    "                qualifiers=attachment_qualifiers\n",
+    "            )\n",
+    "        )\n",
+    "        attachment_claims.append(\n",
+    "            geokb.datatypes.String(\n",
+    "                prop_nr=geokb.prop_lookup['Zotero Attachment Key'],\n",
+    "                value=attachment['key'],\n",
+    "                qualifiers=attachment_qualifiers\n",
+    "            )\n",
+    "        )\n",
+    "    item.claims.add(attachment_claims, action_if_exists=geokb.action_if_exists.REPLACE_ALL)\n",
+    "\n",
+    "    # Write the item data\n",
+    "    try:\n",
+    "        response = item.write(summary=f\"item {'updated' if qid else 'added'} from Zotero source information\")\n",
+    "        print(f\"{'updated' if qid else 'added'} {response.id}\")\n",
+    "    except Exception as e:\n",
+    "        print(str(e))\n",
+    "        display(item.get_json())\n",
+    "        continue\n",
+    "\n",
+    "    # Cache the item and attachment raw source information\n",
+    "    talk_page = geokb.mw_site.pages[f\"Item_talk:{response.id}\"]\n",
+    "    cached_content = {\n",
+    "        'item': source_doc['data'],\n",
+    "        'attachments': [i['data'] for i in source_attachments]\n",
+    "    }\n",
+    "    talk_page.save(yaml.dump(cached_content), summary=f\"cached content from Zotero source information\")\n",
+    "    print('cached source metadata to item talk page')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geokb",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I worked up a new way of syncing a Zotero group library with the GeoKB representation in order to work through the issue that came up with the Blazegraph store. We need this anyway for any group library where we want a representation of reference items in the GeoKB.